### PR TITLE
Include .env in ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local_settings.py
 /static/
 /env/
 **/.DS_Store
+.env


### PR DESCRIPTION
Adds the hidden .env environment settings to gitignore list.